### PR TITLE
fix dead link in autoscheduler paper page

### DIFF
--- a/papers/autoscheduler2019.html
+++ b/papers/autoscheduler2019.html
@@ -119,7 +119,7 @@
         <font size=+1><b>Code</b></font><br>
       <p>
         The core autoscheduler has been integrated into Halide master here:
-        <a target="_blank" href="https://github.com/halide/Halide/tree/master/apps/autoscheduler"> https://github.com/halide/Halide/tree/master/apps/autoscheduler </a>
+        <a target="_blank" href="https://github.com/halide/Halide/tree/master/src/autoschedulers/adams2019"> https://github.com/halide/Halide/tree/master/src/autoschedulers/adams2019 </a>
       </p>
       <p>
         For full details of the experiments and benchmark applications, see this branch in the Halide repository:


### PR DESCRIPTION
Title says it all, link to Adams19 autoscheduler is outdated.