### PR TITLE
The page links are on the left, not the right.

### DIFF
--- a/tutorials/tutorial_introduction.html
+++ b/tutorials/tutorial_introduction.html
@@ -334,6 +334,6 @@ tutorial_lesson_21_auto_scheduler_run.html
 </div>
 <div style="position:relative; margin-left:260px; padding:20px; background-color: #ffffff;">
 <p>
-Halide <u><a href="https://github.com/halide/Halide/releases">releases</a></u> come with a set of tutorials in the form of commented source code. We recommend you learn Halide by reading, compiling, and running them, and by making your own modifications to them. Get your hands dirty! The tutorials can also be browsed here, using the links on the right. In their online form they contain figures and output snippets. For questions or comments, email halide-dev@lists.csail.mit.edu.
+Halide <u><a href="https://github.com/halide/Halide/releases">releases</a></u> come with a set of tutorials in the form of commented source code. We recommend you learn Halide by reading, compiling, and running them, and by making your own modifications to them. Get your hands dirty! The tutorials can also be browsed here, using the links on the left. In their online form they contain figures and output snippets. For questions or comments, email halide-dev@lists.csail.mit.edu.
 </p>
 </div></body></html>


### PR DESCRIPTION
The [tutorial intro page](https://halide-lang.org/tutorials/tutorial_introduction.html) says "using the links on the right".
But the links are on the left.
