### PR TITLE
Include pip instructions on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,15 @@
           <h1>Getting Started</h1>
         </div>
 
-        <p>First, download a <a href="https://github.com/halide/Halide/releases">binary release of Halide</a>.</p>
+        <p>First, install Halide. Even if you only intend to use Halide from C++, pip may be the easiest way to get a binary build of Halide. Full releases may be installed from <a href="https://pypi.org/project/halide">PyPI</a> like so:</p>
+
+        <p><pre class="prettyprint">$ pip install halide</pre></p>
+
+        <p>Every commit to main is published to <a href="https://test.pypi.org/project/halide">Test PyPI</a> as a development version and these may be installed with a few extra flags:</p>
+
+        <p><pre class="prettyprint">$ pip install halide --pre --extra-index-url https://test.pypi.org/simple</pre></p>
+        
+        <p>We also provide binary tarballs on <a href="https://github.com/halide/Halide/releases">GitHub</a>.</p>
 
         <p>For the freshest builds, see the <a href="https://buildbot.halide-lang.org/">continuous build server</a>. The status of the build on each platform is <a href="https://buildbot.halide-lang.org/master/#/builders?tags=%2Bmain">here</a>. If it's green, then it has passed all of our internal tests.</p>
 


### PR DESCRIPTION
Adding links from the homepage to the PyPI and Test PyPI project pages marks the backwards links from the project pages as "verified" on their platform.

Might as well help new users install Halide from the website, too.